### PR TITLE
Documentation

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,7 @@
-MYSQL_ROOT_PASSWORD=password
-LOCAL_DEV_DOMAIN=domain.local
+MYSQL_ROOT_PASSWORD=password!
+LOCAL_DEV_DOMAIN=docker.local
+WP_SITE_TITLE="Site Title"
+WP_ADMIN_USER=admin
+WP_ADMIN_PASSWORD=password!
+WP_ADMIN_EMAIL=email@jam3.com
+

--- a/README.md
+++ b/README.md
@@ -53,13 +53,9 @@ $ git clone https://github.com/Jam3/docker-wordpress-vip-go.git [project-name]
 
 You can check out the logs of the installation using `$ docker-compose logs -f`
 
-### Install WordPress
-
-Navigate to http://example.local/ and manually install WordPress. After the installation is done, ~1min, a new folder `wp-container` will appear in the repository.
-
 ### Setup Repository
 
-1. Go to `/wp-container` and remove the folder `wp-content` and clone your project repository
+1. Go to `/wp-container`, remove the folder `wp-content` and clone your project repository
 
 Note: If you repository doesn't include the default theme `twentynineteen` you will need to keep it in the folder `wp-content`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,25 @@ services:
       back:
         aliases:
           - "${LOCAL_DEV_DOMAIN}"
+  wp-cli:
+    image: "wordpress:cli-php${PHP_VERSION:-7.2}"
+    restart: "on-failure"
+    volumes:
+      - ./wp-container:/var/www/html
+      - ./init.sh:/var/www/html/init.sh
+    command: /var/www/html/init.sh
+    depends_on:
+      - db
+      - wordpress
+    networks:
+      - back
+    environment:
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+      LOCAL_DEV_DOMAIN: "$LOCAL_DEV_DOMAIN"
+      WP_SITE_TITLE: "$WP_SITE_TITLE"
+      WP_ADMIN_USER: "$WP_ADMIN_USER"
+      WP_ADMIN_PASSWORD: "$WP_ADMIN_PASSWORD"
+      WP_ADMIN_EMAIL: "$WP_ADMIN_EMAIL"
   phpmyadmin:
     depends_on:
       - db

--- a/init.sh
+++ b/init.sh
@@ -3,9 +3,9 @@ if $(wp core is-installed); then
     echo "wp installed"
     #returning 0 value marks success
     return 0
+else
+    wp core install --url=$LOCAL_DEV_DOMAIN --title="$WP_SITE_TITLE" --admin_name=$WP_ADMIN_USER --admin_password=$MYSQL_ROOT_PASSWORD --admin_email=$WP_ADMIN_EMAIL
 fi
-
-wp core install --url=$LOCAL_DEV_DOMAIN --title="$WP_SITE_TITLE" --admin_name=$WP_ADMIN_USER --admin_password=$MYSQL_ROOT_PASSWORD --admin_email=$WP_ADMIN_EMAIL
 
 #returning non 0 value marks an error, so the container will start again as it has "restart: on-failure"
 return 1

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,10 @@
+#installing wp
+wp core install --url=$LOCAL_DEV_DOMAIN --title="$WP_SITE_TITLE" --admin_name=$WP_ADMIN_USER --admin_password=$MYSQL_ROOT_PASSWORD --admin_email=$WP_ADMIN_EMAIL
+if $(wp core is-installed); then
+    echo "wp installed"
+    #returning 0 value marks success
+    return 0
+fi
+
+#returning non 0 value marks an error, so the container will start again as it has "restart: on-failure"
+return 1

--- a/init.sh
+++ b/init.sh
@@ -1,10 +1,11 @@
 #installing wp
-wp core install --url=$LOCAL_DEV_DOMAIN --title="$WP_SITE_TITLE" --admin_name=$WP_ADMIN_USER --admin_password=$MYSQL_ROOT_PASSWORD --admin_email=$WP_ADMIN_EMAIL
 if $(wp core is-installed); then
     echo "wp installed"
     #returning 0 value marks success
     return 0
 fi
+
+wp core install --url=$LOCAL_DEV_DOMAIN --title="$WP_SITE_TITLE" --admin_name=$WP_ADMIN_USER --admin_password=$MYSQL_ROOT_PASSWORD --admin_email=$WP_ADMIN_EMAIL
 
 #returning non 0 value marks an error, so the container will start again as it has "restart: on-failure"
 return 1


### PR DESCRIPTION
Updating Documentation
Adding new env variables
Adding new container for wp-cli
Using wp-cli to install wp automatically, deleting the wp installation from the setup.
Adding new .sh script, executed when wp-cli container is mounted, until success.